### PR TITLE
Ignore composer lock and executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 vendor/
+/composer.lock
+/composer.phar


### PR DESCRIPTION
_Really_ minor change, but composer.lock and composer.phar should be ignored for library projects.
