### PR TITLE
Added 0.4 to list of supported react event loops

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,6 @@
         "php": ">=5.3.0",
         "ext-inotify": "*",
         "evenement/evenement": "1.0.*",
-        "react/event-loop": ">=0.2, <0.4"
+        "react/event-loop": "^0.2|^0.3|^0.4"
     }
 }


### PR DESCRIPTION
Currently only 0.2 and 0.3 loops are supported. Just gave it a test run and it works without changes with the 0.4 event loop.