### PR TITLE
incorrect path returned as argument

### DIFF
--- a/src/MKraemer/ReactInotify/Inotify.php
+++ b/src/MKraemer/ReactInotify/Inotify.php
@@ -51,6 +51,7 @@ class Inotify extends EventEmitter
                 // http://php.net/manual/en/inotify.constants.php#constant.in-ignored
                 if (isset($this->watchDescriptors[$event['wd']])) {
                     $path = $this->watchDescriptors[$event['wd']]['path'];
+                    $path = rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
                     $this->emit($event['mask'], array($path . $event['name']));
                 }
             }


### PR DESCRIPTION
```
        $this->notify->on(IN_CREATE | IN_ISDIR, function ($path) {

}

```
// watching `watched/path`
// mkdir watched/path/newdirectory
$path would be 'watched/pathnewdirectory' without this fix.