### PR TITLE
Allow use react/event-loop ^1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,6 @@
         "php": ">=5.3.0",
         "ext-inotify": "*",
         "evenement/evenement": "~1.0|~2.0",
-        "react/event-loop": "^0.2|^0.3|^0.4"
+        "react/event-loop": "^0.2|^0.3|^0.4|^1.1"
     }
 }


### PR DESCRIPTION
I want to use react-inotify for local development with event-loop:^1.1. This makes it available.

I tested it and it works.

Would you like to merge it in the main repository? Thanks!